### PR TITLE
Buscar reservas también en la semana siguiente cuando no hay coincidencias

### DIFF
--- a/tests/arena-helpers.ts
+++ b/tests/arena-helpers.ts
@@ -62,19 +62,25 @@ function pad(n: number): string {
   return n.toString().padStart(2, '0');
 }
 
-function nextAllowedDate(allowedDays: DayOfWeek[]): Date {
+function nextAllowedDate(allowedDays: DayOfWeek[], weekOffset = 0): Date {
   const today = new Date();
-  for (let offset = 0; offset < 14; offset++) {
+  const startOffset = weekOffset * 7;
+
+  for (let offset = startOffset; offset < startOffset + 14; offset++) {
     const candidate = new Date(today.getFullYear(), today.getMonth(), today.getDate() + offset);
     if (allowedDays.includes(candidate.getDay())) return candidate;
   }
   return today;
 }
 
-export async function navigateToSchedule(page: Page, allowedDays: DayOfWeek[]): Promise<void> {
+export async function navigateToSchedule(
+  page: Page,
+  allowedDays: DayOfWeek[],
+  weekOffset = 0
+): Promise<void> {
   console.log("\n📅 Navegando a horario semanal...");
 
-  const scheduleDate = nextAllowedDate(allowedDays);
+  const scheduleDate = nextAllowedDate(allowedDays, weekOffset);
   const fechaIso = `${scheduleDate.getFullYear()}-${pad(scheduleDate.getMonth() + 1)}-${pad(scheduleDate.getDate())}T00:00:00`;
 
   const url = `https://arenaalicante.provis.es/ActividadesColectivas/ActividadesColectivasHorarioSemanal?fecha=${fechaIso}&integration=False&publico=False`;

--- a/tests/gym-reservations.spec.ts
+++ b/tests/gym-reservations.spec.ts
@@ -112,7 +112,7 @@ test('Reservar actividad configurada', async ({ page }) => {
     await login(page);
     await navigateToSchedule(page, cfg.allowedDays);
 
-    const classData = await findClass(page, {
+    let classData = await findClass(page, {
       activityId: cfg.activityId,
       allowedDays: cfg.allowedDays,
       minHour: cfg.minHour,
@@ -120,6 +120,20 @@ test('Reservar actividad configurada', async ({ page }) => {
       label: activityToRun.toUpperCase(),
       requireOpenWindow: cfg.requireOpenWindow ?? true,
     });
+
+    if (!classData) {
+      console.log('🔁 No hubo coincidencias en la semana actual, probando la siguiente semana...');
+
+      await navigateToSchedule(page, cfg.allowedDays, 1);
+      classData = await findClass(page, {
+        activityId: cfg.activityId,
+        allowedDays: cfg.allowedDays,
+        minHour: cfg.minHour,
+        minMinutes: cfg.minMinutes ?? 0,
+        label: activityToRun.toUpperCase(),
+        requireOpenWindow: cfg.requireOpenWindow ?? true,
+      });
+    }
 
     if (classData) {
       const success = await reserveClass(page, classData.Id, activityToRun.toUpperCase());


### PR DESCRIPTION
### Motivation
- Corregir el caso donde al ejecutar el job el viernes no se detectan las clases del lunes siguiente porque la búsqueda solo miraba la semana actual. 
- Permitir seleccionar explícitamente la semana objetivo para construir la URL de horario y así poder intentar reservar en la semana siguiente cuando sea necesario.

### Description
- Añadido el parámetro `weekOffset` a `nextAllowedDate` y `navigateToSchedule` para permitir apuntar a semanas posteriores al calcular la fecha objetivo.  
- Ajustada la iteración en `nextAllowedDate` para comenzar en `weekOffset * 7` días y cubrir la ventana de 14 días desde ese inicio.  
- Modificado el flujo del test en `tests/gym-reservations.spec.ts` para que, si `findClass` no encuentra una clase en la semana actual, vuelva a navegar al horario de la siguiente semana con `navigateToSchedule(..., 1)` y reintente `findClass`.  
- Añadidos logs informativos para el reintento en la semana siguiente y mantener visibilidad del flujo de búsqueda.

### Testing
- Ejecutado el chequeo de TypeScript con `npx tsc --noEmit` y pasó correctamente.  
- No se añadieron pruebas automatizadas nuevas; los cambios se limitan a la navegación/selección de fecha y al flujo de reintento en el test existente.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ad70c27db483339829d0092e958eef)